### PR TITLE
Don't wrap long words early

### DIFF
--- a/modules/skparagraph/src/TextWrapper.cpp
+++ b/modules/skparagraph/src/TextWrapper.cpp
@@ -122,13 +122,24 @@ void TextWrapper::lookAhead(SkScalar maxWidth, Cluster* endOfClusters) {
                 }
                 // If the word is too long we can break it right now and hope it's enough
                 fMinIntrinsicWidth = std::max(fMinIntrinsicWidth, nextWordLength);
-                if (fClusters.endPos() - fClusters.startPos() > 1 ||
+                // By default, the words that are wider than the available width are wrapped in such
+                // a way that, when possible, a part of the long word remains on the previous line
+                // with a shorter word. Commenting out the section below makes the long words go to
+                // the next line, which matches Chrome behavior.
+                //
+                // Example ("Hey hippopotamus"):
+                //
+                // |Hey hippo|    |Hey      |
+                // |potamus  | -> |hippopota|
+                // |         |    |mus      |
+                //
+                /* if (fClusters.endPos() - fClusters.startPos() > 1 ||
                     fWords.empty()) {
                     fTooLongWord = true;
                 } else {
                     // Even if the word is too long there is a very little space on this line.
                     // let's deal with it on the next line.
-                }
+                } */
             }
 
             if (cluster->width() > maxWidth) {

--- a/modules/skparagraph/src/TextWrapper.cpp
+++ b/modules/skparagraph/src/TextWrapper.cpp
@@ -122,6 +122,8 @@ void TextWrapper::lookAhead(SkScalar maxWidth, Cluster* endOfClusters) {
                 }
                 // If the word is too long we can break it right now and hope it's enough
                 fMinIntrinsicWidth = std::max(fMinIntrinsicWidth, nextWordLength);
+
+                // NON-SKIA-UPSTREAMED CHANGE
                 // By default, the words that are wider than the available width are wrapped in such
                 // a way that, when possible, a part of the long word remains on the previous line
                 // with a shorter word. Commenting out the section below makes the long words go to
@@ -140,6 +142,7 @@ void TextWrapper::lookAhead(SkScalar maxWidth, Cluster* endOfClusters) {
                     // Even if the word is too long there is a very little space on this line.
                     // let's deal with it on the next line.
                 } */
+                // END OF NON-SKIA-UPSTREAMED CHANGE
             }
 
             if (cluster->width() > maxWidth) {


### PR DESCRIPTION
Long words are wrapped a bit differently in Skia and Chrome, here is an [example](https://www.canva.com/design/DAEpf_2sA9Q/98oePcd0uTCWx02cPYfPiQ/edit?utm_content=DAEpf_2sA9Q&utm_campaign=designshare&utm_medium=link2&utm_source=sharebutton) of a design that has is rendered differently.
Fortunately, I didn't have to add or modify any code, I only had to remove a small bit of it. That removed bit explicitly says that it achieves the behaviour that we don't want.
### Before
![output renderer](https://user-images.githubusercontent.com/5735967/132785888-262e3f29-3bff-4985-9f88-b87f25e5bd24.png)
### After
![0001-7510440523 chromium](https://user-images.githubusercontent.com/5735967/132785886-8cae2473-23b5-4e5c-8fd9-ba412ae76f84.png)