### PR TITLE
Remove paragraph width rounding

### DIFF
--- a/modules/skparagraph/src/ParagraphImpl.cpp
+++ b/modules/skparagraph/src/ParagraphImpl.cpp
@@ -111,8 +111,13 @@ int32_t ParagraphImpl::unresolvedGlyphs() {
 
 void ParagraphImpl::layout(SkScalar rawWidth) {
 
+    // NON-SKIA-UPSTREAMED CHANGE
+    /*
     // TODO: This rounding is done to match Flutter tests. Must be removed...
     auto floorWidth = SkScalarFloorToScalar(rawWidth);
+    */
+    auto floorWidth = rawWidth;
+    // END OF NON-SKIA-UPSTREAMED CHANGE
 
     if ((!SkScalarIsFinite(rawWidth) || fLongestLine <= floorWidth) &&
         fState >= kLineBroken &&
@@ -192,6 +197,8 @@ void ParagraphImpl::layout(SkScalar rawWidth) {
     this->fOldWidth = floorWidth;
     this->fOldHeight = this->fHeight;
 
+    // NON-SKIA-UPSTREAMED CHANGE
+    /*
     // TODO: This rounding is done to match Flutter tests. Must be removed...
     fMinIntrinsicWidth = littleRound(fMinIntrinsicWidth);
     fMaxIntrinsicWidth = littleRound(fMaxIntrinsicWidth);
@@ -200,7 +207,8 @@ void ParagraphImpl::layout(SkScalar rawWidth) {
     if (fParagraphStyle.getMaxLines() == 1 ||
         (fParagraphStyle.unlimited_lines() && fParagraphStyle.ellipsized())) {
         fMinIntrinsicWidth = fMaxIntrinsicWidth;
-    }
+    } */
+    // END OF NON-SKIA-UPSTREAMED CHANGE
 
     // TODO: Since min and max are calculated differently it's possible to get a rounding error
     //  that would make min > max. Sort it out later, make it the same for now


### PR DESCRIPTION
This led to word wrapping being different from Chrome in some cases. Here is an [example](https://www.canva.com/design/DAEplaKcAvA/Wuc3Vtb3aFBeO-KUeOqrNw/edit?utm_content=DAEplaKcAvA&utm_campaign=designshare&utm_medium=link2&utm_source=sharebutton) of the design with such problem.
### Before
![output renderer](https://user-images.githubusercontent.com/5735967/132812754-150147ab-ae1a-453b-886a-16e5eaddb0ef.png)
### After
![0001-7582062233 chromium](https://user-images.githubusercontent.com/5735967/132812748-aada2205-57d8-4335-9d67-7325490b304c.png)
