### PR TITLE
[CA-21620] Don't count soft breaks as word ends

### DIFF
--- a/modules/skparagraph/src/TextWrapper.cpp
+++ b/modules/skparagraph/src/TextWrapper.cpp
@@ -167,7 +167,12 @@ void TextWrapper::lookAhead(SkScalar maxWidth, Cluster* endOfClusters) {
             fClusters.extend(cluster);
 
             // Keep adding clusters/words
+            // NON-SKIA-UPSTREAMED CHANGE
+            /*
             if (fClusters.endOfWord()) {
+            */
+            if (fClusters.endOfWord() || cluster + 1 == endOfClusters) {
+            // END OF NON-SKIA-UPSTREAMED CHANGE
                 fMinIntrinsicWidth = std::max(fMinIntrinsicWidth, getClustersTrimmedWidth());
                 fWords.extend(fClusters);
             }

--- a/modules/skparagraph/src/TextWrapper.h
+++ b/modules/skparagraph/src/TextWrapper.h
@@ -58,8 +58,14 @@ class TextWrapper {
         inline size_t endPos() const { return fEnd.position(); }
         bool endOfCluster() { return fEnd.position() == fEnd.cluster()->endPos(); }
         bool endOfWord() {
+            // NON-SKIA-UPSTREAMED CHANGE
+            /*
             return endOfCluster() &&
                    (fEnd.cluster()->isHardBreak() || fEnd.cluster()->isSoftBreak());
+            */
+            return endOfCluster() &&
+                   (fEnd.cluster()->isHardBreak() || fEnd.cluster()->isWhitespaceBreak());
+            // END OF NON-SKIA-UPSTREAMED CHANGE
         }
 
         void extend(TextStretch& stretch) {


### PR DESCRIPTION
When characters such as slash character (`/`) are present in the text, Skia and Chrome wrap words a bit differently. This is because Chrome considers `first/second` to be a single word, while Skia thinks it's two different words.

## Skia
![output renderer](https://user-images.githubusercontent.com/5735967/138614860-940f7ab4-8e1f-48a7-b92e-ed2808753f71.png)

## Chrome
![0001-10704530175 chromium](https://user-images.githubusercontent.com/5735967/138614869-d7a9f68d-a848-48b0-9e3d-0ab6f4ce59ee.png)

