### PR TITLE
[CA-21620] Wrap words on hyphens and question marks

### DIFF
--- a/modules/skparagraph/src/ParagraphImpl.cpp
+++ b/modules/skparagraph/src/ParagraphImpl.cpp
@@ -371,6 +371,11 @@ Cluster::Cluster(ParagraphImpl* owner,
     fIsWhiteSpaceBreak = whiteSpacesBreakLen == fTextRange.width();
     fIsIntraWordBreak = intraWordBreakLen == fTextRange.width();
     fIsHardBreak = fOwner->codeUnitHasProperty(fTextRange.end, CodeUnitFlags::kHardLineBreakBefore);
+    // NON-SKIA-UPSTREAMED CHANGE
+    // Chrome doesn't break words on soft breaks, except some characters:
+    fIsChromeBreak = *ch == 0x2D // Hyphen (-)
+                     || *ch == 0x3F; // Question mark (?)
+    // END OF NON-SKIA-UPSTREAMED CHANGE
 }
 
 SkScalar Run::calculateWidth(size_t start, size_t end, bool clip) const {

--- a/modules/skparagraph/src/Run.h
+++ b/modules/skparagraph/src/Run.h
@@ -291,6 +291,9 @@ public:
     bool isWhitespaceBreak() const { return fIsWhiteSpaceBreak; }
     bool isIntraWordBreak() const { return fIsIntraWordBreak; }
     bool isHardBreak() const { return fIsHardBreak; }
+    // NON-SKIA-UPSTREAMED CHANGE
+    bool isChromeBreak() const { return fIsChromeBreak; }
+    // END OF NON-SKIA-UPSTREAMED CHANGE
 
     bool isSoftBreak() const;
     bool isGraphemeBreak() const;
@@ -344,6 +347,9 @@ private:
     bool fIsWhiteSpaceBreak;
     bool fIsIntraWordBreak;
     bool fIsHardBreak;
+    // NON-SKIA-UPSTREAMED CHANGE
+    bool fIsChromeBreak;
+    // END OF NON-SKIA-UPSTREAMED CHANGE
 };
 
 class InternalLineMetrics {

--- a/modules/skparagraph/src/TextWrapper.h
+++ b/modules/skparagraph/src/TextWrapper.h
@@ -63,8 +63,9 @@ class TextWrapper {
             return endOfCluster() &&
                    (fEnd.cluster()->isHardBreak() || fEnd.cluster()->isSoftBreak());
             */
+            Cluster* end = fEnd.cluster();
             return endOfCluster() &&
-                   (fEnd.cluster()->isHardBreak() || fEnd.cluster()->isWhitespaceBreak());
+                    (end->isHardBreak() || end->isWhitespaceBreak() || end->isChromeBreak());
             // END OF NON-SKIA-UPSTREAMED CHANGE
         }
 

--- a/modules/skparagraph/src/TextWrapper.h
+++ b/modules/skparagraph/src/TextWrapper.h
@@ -65,7 +65,7 @@ class TextWrapper {
             */
             Cluster* end = fEnd.cluster();
             return endOfCluster() &&
-                    (end->isHardBreak() || end->isWhitespaceBreak() || end->isChromeBreak());
+                   (end->isHardBreak() || end->isWhitespaceBreak() || end->isChromeBreak());
             // END OF NON-SKIA-UPSTREAMED CHANGE
         }
 


### PR DESCRIPTION
The previous [attempt](https://github.com/romanzes/skia/pull/12) to fix word wrapping in Chrome was based on the assumption that, when wrapping words, Chrome doesn't take into account every character that Skia considers to be a soft break, taking into account whitespace characters only. Apparently, that is not the case - based on S3 comparisons and manual testing, hyphens and question marks (but not exclamation marks, surprisingly) are also treated as word breaks.
Unfortunately, I still wasn't able to find the exact code in Chrome that decides which character is a break and which is not, so I had to rely on S3 comparisons and manual testing on Mac keyboard to find out which characters need special treatment.

## Before
![output renderer](https://user-images.githubusercontent.com/5735967/139382741-c333267f-42db-4ece-adba-8767588f9786.png)
## After
![0001-11056515234 chromium](https://user-images.githubusercontent.com/5735967/139382749-8f5ccc44-1d3a-4b56-a20e-ef82852c2e2f.png)