### PR TITLE
[CA-21705] Add soft break exemptions

### DIFF
--- a/modules/skparagraph/src/ParagraphImpl.cpp
+++ b/modules/skparagraph/src/ParagraphImpl.cpp
@@ -371,11 +371,6 @@ Cluster::Cluster(ParagraphImpl* owner,
     fIsWhiteSpaceBreak = whiteSpacesBreakLen == fTextRange.width();
     fIsIntraWordBreak = intraWordBreakLen == fTextRange.width();
     fIsHardBreak = fOwner->codeUnitHasProperty(fTextRange.end, CodeUnitFlags::kHardLineBreakBefore);
-    // NON-SKIA-UPSTREAMED CHANGE
-    // Chrome doesn't break words on soft breaks, except some characters:
-    fIsChromeBreak = *ch == 0x2D // Hyphen (-)
-                     || *ch == 0x3F; // Question mark (?)
-    // END OF NON-SKIA-UPSTREAMED CHANGE
 }
 
 SkScalar Run::calculateWidth(size_t start, size_t end, bool clip) const {

--- a/modules/skparagraph/src/ParagraphImpl.cpp
+++ b/modules/skparagraph/src/ParagraphImpl.cpp
@@ -374,8 +374,8 @@ Cluster::Cluster(ParagraphImpl* owner,
     // NON-SKIA-UPSTREAMED CHANGE
     // Some of the symbols that Chrome doesn't recognize to be soft breaks,
     // are soft breaks in Skia by default
-    fIsSoftBreakExemption = *ch == 0x0F // Forward slash (/)
-                           || *ch == 0x21 // Exclamation mark (1)
+    fIsSoftBreakExemption = *ch == 0x21 // Exclamation mark (!)
+                           || *ch == 0x2F // Forward slash (/)
                            || *ch == 0x7C // Vertical bar (|)
                            || *ch == 0x7D; // Right brace (})
     // END OF NON-SKIA-UPSTREAMED CHANGE

--- a/modules/skparagraph/src/ParagraphImpl.cpp
+++ b/modules/skparagraph/src/ParagraphImpl.cpp
@@ -371,6 +371,14 @@ Cluster::Cluster(ParagraphImpl* owner,
     fIsWhiteSpaceBreak = whiteSpacesBreakLen == fTextRange.width();
     fIsIntraWordBreak = intraWordBreakLen == fTextRange.width();
     fIsHardBreak = fOwner->codeUnitHasProperty(fTextRange.end, CodeUnitFlags::kHardLineBreakBefore);
+    // NON-SKIA-UPSTREAMED CHANGE
+    // Some of the symbols that Chrome doesn't recognize to be soft breaks,
+    // are soft breaks in Skia by default
+    fIsSoftBreakExemption = *ch == 0x0F // Forward slash (/)
+                           || *ch == 0x21 // Exclamation mark (1)
+                           || *ch == 0x7C // Vertical bar (|)
+                           || *ch == 0x7D; // Right brace (})
+    // END OF NON-SKIA-UPSTREAMED CHANGE
 }
 
 SkScalar Run::calculateWidth(size_t start, size_t end, bool clip) const {

--- a/modules/skparagraph/src/Run.cpp
+++ b/modules/skparagraph/src/Run.cpp
@@ -309,8 +309,12 @@ SkFont Cluster::font() const {
 }
 
 bool Cluster::isSoftBreak() const {
-    return fOwner->codeUnitHasProperty(fTextRange.end, CodeUnitFlags::kSoftLineBreakBefore) &&
-            !isSoftBreakExemption();
+    // NON-SKIA-UPSTREAMED CHANGE
+    if (isSoftBreakExemption()) {
+        return false;
+    }
+    // END OF NON-SKIA-UPSTREAMED CHANGE
+    return fOwner->codeUnitHasProperty(fTextRange.end, CodeUnitFlags::kSoftLineBreakBefore);
 }
 
 bool Cluster::isGraphemeBreak() const {

--- a/modules/skparagraph/src/Run.cpp
+++ b/modules/skparagraph/src/Run.cpp
@@ -309,7 +309,8 @@ SkFont Cluster::font() const {
 }
 
 bool Cluster::isSoftBreak() const {
-    return fOwner->codeUnitHasProperty(fTextRange.end, CodeUnitFlags::kSoftLineBreakBefore);
+    return fOwner->codeUnitHasProperty(fTextRange.end, CodeUnitFlags::kSoftLineBreakBefore) &&
+            !fOwner->isSoftBreakExemption();
 }
 
 bool Cluster::isGraphemeBreak() const {

--- a/modules/skparagraph/src/Run.cpp
+++ b/modules/skparagraph/src/Run.cpp
@@ -310,7 +310,7 @@ SkFont Cluster::font() const {
 
 bool Cluster::isSoftBreak() const {
     return fOwner->codeUnitHasProperty(fTextRange.end, CodeUnitFlags::kSoftLineBreakBefore) &&
-            !fOwner->isSoftBreakExemption();
+            !isSoftBreakExemption();
 }
 
 bool Cluster::isGraphemeBreak() const {

--- a/modules/skparagraph/src/Run.h
+++ b/modules/skparagraph/src/Run.h
@@ -295,6 +295,9 @@ public:
     bool isWhitespaceBreak() const { return fIsWhiteSpaceBreak; }
     bool isIntraWordBreak() const { return fIsIntraWordBreak; }
     bool isHardBreak() const { return fIsHardBreak; }
+    // NON-SKIA-UPSTREAMED CHANGE
+    bool isSoftBreakExemption() const { return fIsSoftBreakExemption; }
+    // END OF NON-SKIA-UPSTREAMED CHANGE
 
     bool isSoftBreak() const;
     bool isGraphemeBreak() const;
@@ -348,6 +351,9 @@ private:
     bool fIsWhiteSpaceBreak;
     bool fIsIntraWordBreak;
     bool fIsHardBreak;
+    // NON-SKIA-UPSTREAMED CHANGE
+    bool fIsSoftBreakExemption;
+    // END OF NON-SKIA-UPSTREAMED CHANGE
 };
 
 class InternalLineMetrics {

--- a/modules/skparagraph/src/Run.h
+++ b/modules/skparagraph/src/Run.h
@@ -295,9 +295,6 @@ public:
     bool isWhitespaceBreak() const { return fIsWhiteSpaceBreak; }
     bool isIntraWordBreak() const { return fIsIntraWordBreak; }
     bool isHardBreak() const { return fIsHardBreak; }
-    // NON-SKIA-UPSTREAMED CHANGE
-    bool isChromeBreak() const { return fIsChromeBreak; }
-    // END OF NON-SKIA-UPSTREAMED CHANGE
 
     bool isSoftBreak() const;
     bool isGraphemeBreak() const;
@@ -351,9 +348,6 @@ private:
     bool fIsWhiteSpaceBreak;
     bool fIsIntraWordBreak;
     bool fIsHardBreak;
-    // NON-SKIA-UPSTREAMED CHANGE
-    bool fIsChromeBreak;
-    // END OF NON-SKIA-UPSTREAMED CHANGE
 };
 
 class InternalLineMetrics {

--- a/modules/skparagraph/src/TextWrapper.cpp
+++ b/modules/skparagraph/src/TextWrapper.cpp
@@ -167,12 +167,7 @@ void TextWrapper::lookAhead(SkScalar maxWidth, Cluster* endOfClusters) {
             fClusters.extend(cluster);
 
             // Keep adding clusters/words
-            // NON-SKIA-UPSTREAMED CHANGE
-            /*
             if (fClusters.endOfWord()) {
-            */
-            if (fClusters.endOfWord() || cluster + 1 == endOfClusters) {
-            // END OF NON-SKIA-UPSTREAMED CHANGE
                 fMinIntrinsicWidth = std::max(fMinIntrinsicWidth, getClustersTrimmedWidth());
                 fWords.extend(fClusters);
             }

--- a/modules/skparagraph/src/TextWrapper.h
+++ b/modules/skparagraph/src/TextWrapper.h
@@ -58,14 +58,8 @@ class TextWrapper {
         inline size_t endPos() const { return fEnd.position(); }
         bool endOfCluster() { return fEnd.position() == fEnd.cluster()->endPos(); }
         bool endOfWord() {
-            // NON-SKIA-UPSTREAMED CHANGE
-            /*
             return endOfCluster() &&
                    (fEnd.cluster()->isHardBreak() || fEnd.cluster()->isSoftBreak());
-            */
-            return endOfCluster() &&
-                   (fEnd.cluster()->isHardBreak() || fEnd.cluster()->isWhitespaceBreak());
-            // END OF NON-SKIA-UPSTREAMED CHANGE
         }
 
         void extend(TextStretch& stretch) {

--- a/modules/skparagraph/src/TextWrapper.h
+++ b/modules/skparagraph/src/TextWrapper.h
@@ -63,9 +63,8 @@ class TextWrapper {
             return endOfCluster() &&
                    (fEnd.cluster()->isHardBreak() || fEnd.cluster()->isSoftBreak());
             */
-            Cluster* end = fEnd.cluster();
             return endOfCluster() &&
-                   (end->isHardBreak() || end->isWhitespaceBreak() || end->isChromeBreak());
+                   (fEnd.cluster()->isHardBreak() || fEnd.cluster()->isWhitespaceBreak());
             // END OF NON-SKIA-UPSTREAMED CHANGE
         }
 


### PR DESCRIPTION
This PR reverts the following two: #12, #13. These PRs disabled text wrapping on soft breaks, with the exception of two characters: hyphen (-) and question mark (?). This worked well for most alphabets and text was wrapping the same way as in Chrome. However, as we recently found, Chinese text is using its own punctuation symbols and the fix we had didn't work well with them, since Skia now treated the entire text as a single non-breaking word. At the same time, official Skia didn't have this problem, only our fork had.

The current fix tackles the problem from the opposite end - soft breaks are brought back, and the exceptions are added for those characters that are not wrapping in Chrome even if Skia thinks they should be soft breaks. I had to find these exceptions manually by checking each symbol from the following list:
```
` - doesn't wrap in both
~ - doesn't wrap in both
! - doesn't wrap in Chrome, wraps in Skia
@ - doesn't wrap in both
# - doesn't wrap in both
$ - doesn't wrap in both
% - doesn't wrap in both
^ - doesn't wrap in both
& - doesn't wrap in both
* - doesn't wrap in both
( - doesn't wrap in both
) - doesn't wrap in both
- - wraps in both
_ - doesn't wrap in both
= - doesn't wrap in both
+ - doesn't wrap in both
[ - doesn't wrap in both
] - doesn't wrap in both
{ - doesn't wrap in both
} - doesn't wrap in Chrome, wraps in Skia
\ - doesn't wrap in both
| - doesn't wrap in Chrome, wraps in Skia
; - doesn't wrap in both
: - doesn't wrap in both
' - doesn't wrap in both
" - doesn't wrap in both
, - doesn't wrap in both
. - doesn't wrap in both
< - doesn't wrap in both
> - doesn't wrap in both
/ - doesn't wrap in Chrome, wraps in Skia
? - wraps in both
```
Based on this data, I concluded that the exceptions should be for: `!`, `}`, `|`, and `/`.

### Before
![output renderer](https://user-images.githubusercontent.com/5735967/149450582-f7e14674-3d18-4dcd-b993-adba69dd296c.png)

### After
![0001-16549431509 chromium](https://user-images.githubusercontent.com/5735967/149450596-a130ccd6-1010-4c1a-9e38-8786bba0b8e8.png)

