### PR TITLE
Fix disappearing letters

### DIFF
--- a/modules/skparagraph/src/TextWrapper.cpp
+++ b/modules/skparagraph/src/TextWrapper.cpp
@@ -33,6 +33,17 @@ struct LineBreakerWithLittleRounding {
 
     const SkScalar fLower, fMaxWidth, fUpper;
 };
+
+struct LineBreakerWithoutLittleRounding {
+    LineBreakerWithoutLittleRounding(SkScalar maxWidth)
+            , fMaxWidth(maxWidth) {}
+
+    bool breakLine(SkScalar width) const {
+        return width > fMaxWidth;
+    }
+
+    const SkScalar fMaxWidth;
+};
 }  // namespace
 
 // Since we allow cluster clipping when they don't fit
@@ -45,7 +56,7 @@ void TextWrapper::lookAhead(SkScalar maxWidth, Cluster* endOfClusters) {
     fClusters.startFrom(fEndLine.startCluster(), fEndLine.startPos());
     fClip.startFrom(fEndLine.startCluster(), fEndLine.startPos());
 
-    LineBreakerWithLittleRounding breaker(maxWidth);
+    LineBreakerWithoutLittleRounding breaker(maxWidth);
     Cluster* nextNonBreakingSpace = nullptr;
     for (auto cluster = fEndLine.endCluster(); cluster < endOfClusters; ++cluster) {
         if (cluster->isHardBreak()) {

--- a/modules/skparagraph/src/TextWrapper.cpp
+++ b/modules/skparagraph/src/TextWrapper.cpp
@@ -36,7 +36,7 @@ struct LineBreakerWithLittleRounding {
 
 struct LineBreakerWithoutLittleRounding {
     LineBreakerWithoutLittleRounding(SkScalar maxWidth)
-            , fMaxWidth(maxWidth) {}
+        : fMaxWidth(maxWidth) {}
 
     bool breakLine(SkScalar width) const {
         return width > fMaxWidth;

--- a/modules/skparagraph/src/TextWrapper.cpp
+++ b/modules/skparagraph/src/TextWrapper.cpp
@@ -56,7 +56,10 @@ void TextWrapper::lookAhead(SkScalar maxWidth, Cluster* endOfClusters) {
     fClusters.startFrom(fEndLine.startCluster(), fEndLine.startPos());
     fClip.startFrom(fEndLine.startCluster(), fEndLine.startPos());
 
+    // NON-SKIA-UPSTREAMED CHANGE
+    // LineBreakerWithLittleRounding breaker(maxWidth);
     LineBreakerWithoutLittleRounding breaker(maxWidth);
+    // END OF NON-SKIA-UPSTREAMED CHANGE
     Cluster* nextNonBreakingSpace = nullptr;
     for (auto cluster = fEndLine.endCluster(); cluster < endOfClusters; ++cluster) {
         if (cluster->isHardBreak()) {


### PR DESCRIPTION
Skia has a line breaker which does weird things trying to take paragraph width rounding into account: https://github.com/romanzes/skia/blob/da83814a244d4536bbc57ec2ceba5a25afe3e52f/modules/skparagraph/src/TextWrapper.cpp#L9-L35
Just like paragraph rounding itself, it was introduced in order for some Flutter-specific tests to pass, see this commit: https://github.com/google/skia/commit/965e4442192bfb23243ee7ef906afca6effe9269
At some point, we removed paragraph width rounding: https://github.com/romanzes/skia/pull/11. That means, that we don't actually need this hacky line breaker and can replace it with a trivial one, which is exactly what this PR does.

An example of a bug which this PR solves:
<img width="664" alt="UACnA0hERM4_uploads_4c7ff5ab-c0ad-4321-a5fc-305a1434ecad png" src="https://user-images.githubusercontent.com/5735967/187585977-083e626b-b313-4df8-ac7a-9feb405e3a2c.png">
