### PR TITLE
Fix aliased embedded rasters when downscaling

### DIFF
--- a/modules/svg/src/SkSVGImage.cpp
+++ b/modules/svg/src/SkSVGImage.cpp
@@ -88,8 +88,14 @@ void SkSVGImage::onRender(const SkSVGRenderContext& ctx) const {
     }
 
     // TODO: image-rendering property
+    // NON-SKIA-UPSTREAMED CHANGE
+    /*
     ctx.canvas()->drawImageRect(
             imgInfo.fImage, imgInfo.fDst, SkSamplingOptions(SkFilterMode::kLinear));
+    */
+    ctx.canvas()->drawImageRect(imgInfo.fImage, imgInfo.fDst,
+                                SkSamplingOptions(SkFilterMode::kLinear, SkMipmapMode::kLinear));
+    // END OF NON-SKIA-UPSTREAMED CHANGE
 }
 
 SkPath SkSVGImage::onAsPath(const SkSVGRenderContext&) const { return {}; }


### PR DESCRIPTION
Before:
<img width="102" alt="262882732-eb26999e-6bb4-4564-bf75-88fa76c39e05" src="https://github.com/romanzes/skia/assets/5735967/2919e398-f760-4b0e-beb1-ca933acdb94e">

After:
<img width="102" alt="262882732-eb26999e-6bb4-4564-bf75-88fa76c39e05" src="https://github.com/romanzes/skia/assets/5735967/1886a02f-80af-4d52-95cb-507b20d76355">