### PR TITLE
Fix filter property propagation

### DIFF
--- a/modules/svg/include/SkSVGFilter.h
+++ b/modules/svg/include/SkSVGFilter.h
@@ -15,6 +15,11 @@ class SK_API SkSVGFilter final : public SkSVGHiddenContainer {
 public:
     static sk_sp<SkSVGFilter> Make() { return sk_sp<SkSVGFilter>(new SkSVGFilter()); }
 
+    // NON-SKIA-UPSTREAMED CHANGE
+    /** Propagates any inherited presentation attributes in the given context. */
+    void applyProperties(SkSVGRenderContext*) const;
+    // END OF NON-SKIA-UPSTREAMED CHANGE
+
     sk_sp<SkImageFilter> buildFilterDAG(const SkSVGRenderContext&) const;
 
     SVG_ATTR(X, SkSVGLength, SkSVGLength(-10, SkSVGLength::Unit::kPercentage))

--- a/modules/svg/src/SkSVGFilter.cpp
+++ b/modules/svg/src/SkSVGFilter.cpp
@@ -25,13 +25,17 @@ bool SkSVGFilter::parseAndSetAttribute(const char* name, const char* value) {
                    "primitiveUnits", name, value));
 }
 
+// NON-SKIA-UPSTREAMED CHANGE
+void SkSVGFilter::applyProperties(SkSVGRenderContext* ctx) const { this->onPrepareToRender(ctx); }
+// END OF NON-SKIA-UPSTREAMED CHANGE
+
 sk_sp<SkImageFilter> SkSVGFilter::buildFilterDAG(const SkSVGRenderContext& ctx) const {
     sk_sp<SkImageFilter> filter;
     SkSVGFilterContext fctx(ctx.resolveOBBRect(fX, fY, fWidth, fHeight, fFilterUnits),
                             fPrimitiveUnits);
     // NON-SKIA-UPSTREAMED CHANGE
     SkSVGRenderContext lctx(ctx);
-    this->onPrepareToRender(&lctx);
+    this->applyProperties(&lctx);
     // END OF NON-SKIA-UPSTREAMED CHANGE
     SkSVGColorspace cs = SkSVGColorspace::kSRGB;
     for (const auto& child : fChildren) {

--- a/modules/svg/src/SkSVGFilter.cpp
+++ b/modules/svg/src/SkSVGFilter.cpp
@@ -29,6 +29,10 @@ sk_sp<SkImageFilter> SkSVGFilter::buildFilterDAG(const SkSVGRenderContext& ctx) 
     sk_sp<SkImageFilter> filter;
     SkSVGFilterContext fctx(ctx.resolveOBBRect(fX, fY, fWidth, fHeight, fFilterUnits),
                             fPrimitiveUnits);
+    // NON-SKIA-UPSTREAMED CHANGE
+    SkSVGRenderContext lctx(ctx);
+    this->onPrepareToRender(&lctx);
+    // END OF NON-SKIA-UPSTREAMED CHANGE
     SkSVGColorspace cs = SkSVGColorspace::kSRGB;
     for (const auto& child : fChildren) {
         if (!SkSVGFe::IsFilterEffect(child)) {
@@ -42,11 +46,17 @@ sk_sp<SkImageFilter> SkSVGFilter::buildFilterDAG(const SkSVGRenderContext& ctx) 
         // color-interpolation-filters). We call this explicitly here because the SkSVGFe
         // nodes do not participate in the normal onRender path, which is when property
         // propagation currently occurs.
-        SkSVGRenderContext localCtx(ctx);
+        // NON-SKIA-UPSTREAMED CHANGE
+        // SkSVGRenderContext localCtx(ctx);
+        SkSVGRenderContext localCtx(lctx);
+        // END OF NON-SKIA-UPSTREAMED CHANGE
         feNode.applyProperties(&localCtx);
 
         const SkRect filterSubregion = feNode.resolveFilterSubregion(localCtx, fctx);
-        cs = feNode.resolveColorspace(ctx, fctx);
+        // NON-SKIA-UPSTREAMED CHANGE
+        // cs = feNode.resolveColorspace(ctx, fctx);
+        cs = feNode.resolveColorspace(localCtx, fctx);
+        // END OF NON-SKIA-UPSTREAMED CHANGE
         filter = feNode.makeImageFilter(localCtx, fctx);
 
         if (!feResultType.isEmpty()) {


### PR DESCRIPTION
A bug was reported to us through CHT (see [CA-22234](https://canvadev.atlassian.net/browse/CA-22234)) about gradients looking incorrectly.

## Output
![output](https://github.com/romanzes/skia/assets/5735967/6768ce68-f234-4ae8-a884-4adc6c2481e4)

## Expected
![output](https://github.com/romanzes/skia/assets/5735967/fe5bd6ce-647f-4943-8990-6280f544bef7)

I noticed that removing `color-interpolation-filters="sRGB"` attribute from the SVG makes it look like Skia's output. The default value for `color-interpolation-filters` is `linearRGB`, so it meant that Skia somehow didn't recognise that the attribute was specified as `sRGB`, despite clearly having the logic to support both options (see [here](https://github.com/google/skia/blob/13d61eccb318db473f8d88f3e37fbcabefce0bfb/modules/svg/src/SkSVGFilterContext.cpp#L20-L31)).

Using print statements in Skia code I was able to determine where exactly it loses the attribute value. There are actually two reasons for this, and this PR fixes them both, see comments in the PR for explanations.
